### PR TITLE
Update init.lua

### DIFF
--- a/peachy/init.lua
+++ b/peachy/init.lua
@@ -31,8 +31,8 @@ local peachy = {
 }
 
 local PATH = (...):gsub("%.[^%.]+$", "")
-local json = require(PATH..".peachy.lib.json")
-local cron = require(PATH..".peachy.lib.cron")
+local json = require(PATH..".lib.json")
+local cron = require(PATH..".lib.cron")
 
 peachy.__index = peachy
 


### PR DESCRIPTION
when the single frame duration is set to 65535 ms, the entire animation will be frozen
Fixed the issue where the animation frame was not reset in time when setting the animation tag