### PR TITLE
Support ".aseprite" and ".ase" extensions

### DIFF
--- a/peachy/init.lua
+++ b/peachy/init.lua
@@ -373,7 +373,7 @@ function peachy:__convertHashFramesToArray()
 	local framesArray = {}
 
 	for filename, frameData in pairs(self.__jsonData.frames) do
-		local frameIndex = tonumber(filename:match("(%d+)%.aseprite"))
+		local frameIndex = tonumber(filename:match("(%d+)%.aseprite") or filename:match("(%d+)%.ase"))
 
 		if frameIndex then
 			frameData.filename = filename


### PR DESCRIPTION
Hi,

I dont know if it's because i use LibreSprite, but i got `.ase` instead of `.aseprite` inside the json file.
That patch fix it for me.

Patch note:
_Extends filename parsing to support both ".aseprite" and ".ase" extensions, ensuring compatibility with different Aseprite file formats._

My generated json:
<img width="783" height="703" alt="image" src="https://github.com/user-attachments/assets/3be46e27-9e16-4980-9387-da90436f5de9" />